### PR TITLE
Set MPLCONFIGDIR on Repl

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MPLCONFIGDIR="/tmp/matplotlib-freecodecamp"


### PR DESCRIPTION
Without setting the environment variable on Repl, the following warning is shown.

> Matplotlib created a temporary config/cache directory at /tmp/matplotlib-{random-string} because the default path (/config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.

This prevents the warning from appearing on Repl, as well as providing the benefits the warning describes.

---

I also believe this change should be added to:
* Page-View-Time-Series-Visualizer
* Sea-Level-Predictor

But first I'd like to verify your opinion on it here before I create other PRs.