### PR TITLE
fix(learn): Update .replit to reenable the package manager button

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,109 @@
+# The command that runs the program. Commented out because it is not run when the interpreter command is set
+# run = ["python3", "main.py"]
+# The primary language of the repl. There can be others, though!
 language = "python3"
-run = "python main.py" 
+# The main file, which will be shown by default in the editor.
+entrypoint = "main.py"
+# A list of globs that specify which files and directories should
+# be hidden in the workspace.
+hidden = ["venv", ".config", "**/__pycache__", "**/.mypy_cache", "**/*.pyc"]
+
+# Specifies which nix channel to use when building the environment.
+[nix]
+channel = "stable-21_11"
+
+# Per-language configuration: python3
+[languages.python3]
+# Treats all files that end with `.py` as Python.
+pattern = "**/*.py"
+# Tells the workspace editor to syntax-highlight these files as
+# Python.
+syntax = "python"
+
+  # The command needed to start the Language Server Protocol. For
+  # linting and formatting.
+  [languages.python3.languageServer]
+  start = ["pylsp"]
+
+# The command to start the interpreter.
+[interpreter]
+  [interpreter.command]
+  args = [
+    "stderred",
+    "--",
+    "prybar-python3",
+    "-q",
+    "--ps1",
+    "\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ",
+    "-i",
+  ]
+  env = { LD_LIBRARY_PATH = "$PYTHON_LD_LIBRARY_PATH" }
+
+# The environment variables needed to correctly start Python and use the
+# package proxy.
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
+MPLBACKEND="TkAgg"
+POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
+
+# Enable unit tests. This is only supported for a few languages.
+[unitTest]
+language = "python3"
+
+# Add a debugger!
+[debugger]
+support = true
+
+  # How to start the debugger.
+  [debugger.interactive]
+  transport = "localhost:0"
+  startCommand = ["dap-python", "main.py"]
+
+    # How to communicate with the debugger.
+    [debugger.interactive.integratedAdapter]
+    dapTcpAddress = "localhost:0"
+
+    # How to tell the debugger to start a debugging session.
+    [debugger.interactive.initializeMessage]
+    command = "initialize"
+    type = "request"
+
+      [debugger.interactive.initializeMessage.arguments]
+      adapterID = "debugpy"
+      clientID = "replit"
+      clientName = "replit.com"
+      columnsStartAt1 = true
+      linesStartAt1 = true
+      locale = "en-us"
+      pathFormat = "path"
+      supportsInvalidatedEvent = true
+      supportsProgressReporting = true
+      supportsRunInTerminalRequest = true
+      supportsVariablePaging = true
+      supportsVariableType = true
+
+    # How to tell the debugger to start the debuggee application.
+    [debugger.interactive.launchMessage]
+    command = "attach"
+    type = "request"
+
+      [debugger.interactive.launchMessage.arguments]
+      logging = {}
+
+# Configures the packager.
+[packager]
+# Search packages in PyPI.
+language = "python3"
+# Never attempt to install `unit_tests`. If there are packages that are being
+# guessed wrongly, add them here.
+ignoredPackages = ["unit_tests"]
+
+  [packager.features]
+  enabledForHosting = false
+  # Enable searching packages from the sidebar.
+  packageSearch = true
+  # Enable guessing what packages are needed from the code.
+  guessImports = true


### PR DESCRIPTION
If there is no previous configuration made, the package manager is hidden, and so, a user cannot install any libraries via pip.
I have included the contents of the default Python Template file because it works fine.
This issue is present in the other repos as well, it would be great if you could fix it in order to help devs. I, for one, downloaded the repo and solved locally, only to then copy and paste it to repl.it. I found out just today about this solution so I thought I'd share it!

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
