### PR TITLE
remove .replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,0 @@
-language = "python3"
-run = "python main.py" 


### PR DESCRIPTION
This .replit file breaks a lot of Replit's functionality on import.
Our GitHub import tool now adds the proper .replit file, so removing this will make it run better when imported.

Source: I'm a Support Engineer at Replit

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
